### PR TITLE
Revert "Upgrade bundler from 1.9.7 to 1.11.2"

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -14,7 +14,7 @@ class LanguagePack::Ruby < LanguagePack::Base
   NAME                 = "ruby"
   LIBYAML_VERSION      = "0.1.6"
   LIBYAML_PATH         = "libyaml-#{LIBYAML_VERSION}"
-  BUNDLER_VERSION      = "1.11.2"
+  BUNDLER_VERSION      = "1.9.7"
   BUNDLER_GEM_PATH     = "bundler-#{BUNDLER_VERSION}"
   DEFAULT_RUBY_VERSION = "ruby-2.0.0"
   RBX_BASE_URL         = "http://binaries.rubini.us/heroku"


### PR DESCRIPTION
This reverts commit 8636922d1bb9ea23d4033644f08e6dea18c32893.

apparently this doesn't use rubygems to install the bundler version

```
remote: /tmp/buildpack20160126-166-116re5f/lib/language_pack/shell_helpers.rb:49:in `run!': Command: 'set -o pipefail; curl --fail --retry 3 --retry-delay 1 --connect-timeout 3 --max-time 30 https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/bundler-1.11.2.tgz -s -o - | tar zxf - ' failed unexpectedly: (LanguagePack::Fetcher::FetchError)
```